### PR TITLE
Split active from queue

### DIFF
--- a/api/stok.goalspike.com/v1alpha1/workspace_types.go
+++ b/api/stok.goalspike.com/v1alpha1/workspace_types.go
@@ -18,6 +18,7 @@ func init() {
 // Workspace is the Schema for the workspaces API
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=workspaces,scope=Namespaced
+// +kubebuilder:printcolumn:name="Active",type="string",JSONPath=".status.active"
 // +kubebuilder:printcolumn:name="Queue",type="string",JSONPath=".status.queue"
 // +kubebuilder:printcolumn:name="Backend",type="string",JSONPath=".spec.backend.type"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
@@ -121,8 +122,9 @@ func (ws *Workspace) SetDebug(debug bool) { ws.Spec.Debug = debug }
 
 // WorkspaceStatus defines the observed state of Workspace
 type WorkspaceStatus struct {
-	Queue []string       `json:"queue"`
-	Phase WorkspacePhase `json:"phase"`
+	Active string         `json:"active"`
+	Queue  []string       `json:"queue"`
+	Phase  WorkspacePhase `json:"phase"`
 }
 
 type WorkspacePhase string

--- a/config/crd/bases/stok.goalspike.com_all.yaml
+++ b/config/crd/bases/stok.goalspike.com_all.yaml
@@ -137,6 +137,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.active
+      name: Active
+      type: string
     - jsonPath: .status.queue
       name: Queue
       type: string
@@ -229,6 +232,8 @@ spec:
           status:
             description: WorkspaceStatus defines the observed state of Workspace
             properties:
+              active:
+                type: string
               phase:
                 type: string
               queue:
@@ -236,6 +241,7 @@ spec:
                   type: string
                 type: array
             required:
+            - active
             - phase
             - queue
             type: object

--- a/config/crd/bases/stok.goalspike.com_workspaces.yaml
+++ b/config/crd/bases/stok.goalspike.com_workspaces.yaml
@@ -17,6 +17,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.active
+      name: Active
+      type: string
     - jsonPath: .status.queue
       name: Queue
       type: string
@@ -109,6 +112,8 @@ spec:
           status:
             description: WorkspaceStatus defines the observed state of Workspace
             properties:
+              active:
+                type: string
               phase:
                 type: string
               queue:
@@ -116,6 +121,7 @@ spec:
                   type: string
                 type: array
             required:
+            - active
             - phase
             - queue
             type: object

--- a/controllers/run_controller.go
+++ b/controllers/run_controller.go
@@ -70,16 +70,17 @@ func (r *RunReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		return reconcile.Result{}, err
 	}
 
-	// Check workspace queue position
-	pos := slice.StringIndex(ws.Status.Queue, run.GetName())
-	switch {
-	case pos == 0:
+	// Check if workspace has activated run
+	if ws.Status.Active == run.GetName() {
 		// Currently scheduled to run; get or create pod
 		return r.reconcilePod(req, run, ws)
-	case pos > 0:
+	}
+
+	// Check if workspace has enqueued run
+	if slice.ContainsString(ws.Status.Queue, run.GetName()) {
 		// Queued
 		run.SetPhase(v1alpha1.RunPhaseQueued)
-	case pos < 0:
+	} else {
 		// Not yet queued
 		run.SetPhase(v1alpha1.RunPhasePending)
 	}

--- a/controllers/run_controller_test.go
+++ b/controllers/run_controller_test.go
@@ -45,7 +45,7 @@ func TestRunReconciler(t *testing.T) {
 			name: "Queued",
 			run:  testobj.Run("operator-test", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			objs: []runtime.Object{
-				testobj.Workspace("operator-test", "workspace-1", testobj.WithQueue("plan-0", "plan-1")),
+				testobj.Workspace("operator-test", "workspace-1", testobj.WithActive("plan-0"), testobj.WithQueue("plan-1")),
 				testobj.RunPod("operator-test", "plan-1", testobj.WithPhase(corev1.PodPending)),
 			},
 			assertions: func(run *v1alpha1.Run) {
@@ -56,7 +56,7 @@ func TestRunReconciler(t *testing.T) {
 			name: "Running",
 			run:  testobj.Run("operator-test", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			objs: []runtime.Object{
-				testobj.Workspace("operator-test", "workspace-1", testobj.WithQueue("plan-1")),
+				testobj.Workspace("operator-test", "workspace-1", testobj.WithActive("plan-1")),
 				testobj.RunPod("operator-test", "plan-1"),
 			},
 			assertions: func(run *v1alpha1.Run) {
@@ -67,7 +67,7 @@ func TestRunReconciler(t *testing.T) {
 			name: "Completed",
 			run:  testobj.Run("operator-test", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			objs: []runtime.Object{
-				testobj.Workspace("operator-test", "workspace-1", testobj.WithQueue("plan-1")),
+				testobj.Workspace("operator-test", "workspace-1", testobj.WithActive("plan-1")),
 				testobj.RunPod("operator-test", "plan-1", testobj.WithPhase(corev1.PodSucceeded)),
 			},
 			assertions: func(run *v1alpha1.Run) {
@@ -113,7 +113,7 @@ func TestRunReconciler(t *testing.T) {
 			name: "Creates pod",
 			run:  testobj.Run("operator-test", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			objs: []runtime.Object{
-				testobj.Workspace("operator-test", "workspace-1", testobj.WithQueue("plan-1")),
+				testobj.Workspace("operator-test", "workspace-1", testobj.WithActive("plan-1")),
 			},
 			assertions: func(pod *corev1.Pod) {
 				assert.NotEqual(t, &corev1.Pod{}, pod)
@@ -123,7 +123,7 @@ func TestRunReconciler(t *testing.T) {
 			name: "Sets google credentials",
 			run:  testobj.Run("operator-test", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			objs: []runtime.Object{
-				testobj.Workspace("operator-test", "workspace-1", testobj.WithQueue("plan-1"), testobj.WithSecret("secret-1")),
+				testobj.Workspace("operator-test", "workspace-1", testobj.WithActive("plan-1"), testobj.WithSecret("secret-1")),
 				testobj.Secret("operator-test", "secret-1", testobj.WithStringData("google_application_credentials.json", "abc")),
 			},
 			assertions: func(pod *corev1.Pod) {
@@ -140,7 +140,7 @@ func TestRunReconciler(t *testing.T) {
 			name: "Sets workspace environment variable",
 			run:  testobj.Run("operator-test", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			objs: []runtime.Object{
-				testobj.Workspace("operator-test", "workspace-1", testobj.WithQueue("plan-1")),
+				testobj.Workspace("operator-test", "workspace-1", testobj.WithActive("plan-1")),
 			},
 			assertions: func(pod *corev1.Pod) {
 				want := "operator-test-workspace-1"
@@ -156,7 +156,7 @@ func TestRunReconciler(t *testing.T) {
 			name: "Image name",
 			run:  testobj.Run("operator-test", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			objs: []runtime.Object{
-				testobj.Workspace("operator-test", "workspace-1", testobj.WithQueue("plan-1")),
+				testobj.Workspace("operator-test", "workspace-1", testobj.WithActive("plan-1")),
 			},
 			assertions: func(pod *corev1.Pod) {
 				require.Equal(t, "a.b.c/d:v1", pod.Spec.Containers[0].Image)
@@ -166,7 +166,7 @@ func TestRunReconciler(t *testing.T) {
 			name: "Sets container args",
 			run:  testobj.Run("operator-test", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			objs: []runtime.Object{
-				testobj.Workspace("operator-test", "workspace-1", testobj.WithQueue("plan-1")),
+				testobj.Workspace("operator-test", "workspace-1", testobj.WithActive("plan-1")),
 			},
 			assertions: func(pod *corev1.Pod) {
 				require.Equal(t, []string{"--", "terraform", "plan"}, pod.Spec.Containers[0].Args)

--- a/controllers/workspace_controller_test.go
+++ b/controllers/workspace_controller_test.go
@@ -29,6 +29,7 @@ func TestReconcileWorkspaceStatus(t *testing.T) {
 			name:      "No runs",
 			workspace: testobj.Workspace("", "workspace-1"),
 			assertions: func(ws *v1alpha1.Workspace) {
+				require.Equal(t, "", ws.Status.Active)
 				require.Equal(t, []string{}, ws.Status.Queue)
 			},
 		},
@@ -39,7 +40,8 @@ func TestReconcileWorkspaceStatus(t *testing.T) {
 				testobj.Run("", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			},
 			assertions: func(ws *v1alpha1.Workspace) {
-				require.Equal(t, []string{"plan-1"}, ws.Status.Queue)
+				require.Equal(t, "plan-1", ws.Status.Active)
+				require.Equal(t, []string{}, ws.Status.Queue)
 			},
 		},
 		{
@@ -51,7 +53,8 @@ func TestReconcileWorkspaceStatus(t *testing.T) {
 				testobj.Run("", "plan-3", "plan", testobj.WithWorkspace("workspace-2")),
 			},
 			assertions: func(ws *v1alpha1.Workspace) {
-				require.Equal(t, []string{"plan-1", "plan-2"}, ws.Status.Queue)
+				require.Equal(t, "plan-1", ws.Status.Active)
+				require.Equal(t, []string{"plan-2"}, ws.Status.Queue)
 			},
 		},
 		{
@@ -62,50 +65,8 @@ func TestReconcileWorkspaceStatus(t *testing.T) {
 				testobj.Run("", "plan-2", "plan", testobj.WithWorkspace("workspace-1")),
 			},
 			assertions: func(ws *v1alpha1.Workspace) {
-				require.Equal(t, []string{"plan-1", "plan-2"}, ws.Status.Queue)
-			},
-		},
-		{
-			name:      "Completed command",
-			workspace: testobj.Workspace("", "workspace-1", testobj.WithQueue("plan-3", "plan-1", "plan-2")),
-			objs: []runtime.Object{
-				testobj.Run("", "plan-3", "plan", testobj.WithWorkspace("workspace-1"), testobj.WithRunPhase(v1alpha1.RunPhaseCompleted)),
-				testobj.Run("", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
-				testobj.Run("", "plan-2", "plan", testobj.WithWorkspace("workspace-1")),
-			},
-			assertions: func(ws *v1alpha1.Workspace) {
-				require.Equal(t, []string{"plan-1", "plan-2"}, ws.Status.Queue)
-			},
-		},
-		{
-			name:      "Completed command replaced by incomplete command",
-			workspace: testobj.Workspace("", "workspace-1", testobj.WithQueue("plan-3")),
-			objs: []runtime.Object{
-				testobj.Run("", "plan-3", "plan", testobj.WithWorkspace("workspace-1"), testobj.WithRunPhase(v1alpha1.RunPhaseCompleted)),
-				testobj.Run("", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
-			},
-			assertions: func(ws *v1alpha1.Workspace) {
-				require.Equal(t, []string{"plan-1"}, ws.Status.Queue)
-			},
-		},
-		{
-			name:      "Unapproved privileged command",
-			workspace: testobj.Workspace("", "workspace-1", testobj.WithPrivilegedCommands("plan")),
-			objs: []runtime.Object{
-				testobj.Run("", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
-			},
-			assertions: func(ws *v1alpha1.Workspace) {
-				require.Equal(t, []string{}, ws.Status.Queue)
-			},
-		},
-		{
-			name:      "Approved privileged command",
-			workspace: testobj.Workspace("", "workspace-1", testobj.WithPrivilegedCommands("plan"), testobj.WithQueue("plan-1"), testobj.WithApprovals("plan-1")),
-			objs: []runtime.Object{
-				testobj.Run("", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
-			},
-			assertions: func(ws *v1alpha1.Workspace) {
-				require.Equal(t, []string{"plan-1"}, ws.Status.Queue)
+				require.Equal(t, "plan-1", ws.Status.Active)
+				require.Equal(t, []string{"plan-2"}, ws.Status.Queue)
 			},
 		},
 		{

--- a/controllers/workspace_queue_test.go
+++ b/controllers/workspace_queue_test.go
@@ -18,13 +18,14 @@ func TestUpdateQueue(t *testing.T) {
 		name       string
 		workspace  *v1alpha1.Workspace
 		runs       []runtime.Object
-		assertions func([]string)
+		assertions func(string, []string)
 	}{
 		{
 			name:      "No runs",
 			workspace: testobj.Workspace("default", "workspace-1"),
 			runs:      []runtime.Object{},
-			assertions: func(queue []string) {
+			assertions: func(active string, queue []string) {
+				require.Equal(t, "", active)
 				require.Equal(t, []string{}, queue)
 			},
 		},
@@ -34,8 +35,9 @@ func TestUpdateQueue(t *testing.T) {
 			runs: []runtime.Object{
 				testobj.Run("default", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 			},
-			assertions: func(queue []string) {
-				require.Equal(t, []string{"plan-1"}, queue)
+			assertions: func(active string, queue []string) {
+				require.Equal(t, "plan-1", active)
+				require.Equal(t, []string{}, queue)
 			},
 		},
 		{
@@ -45,8 +47,9 @@ func TestUpdateQueue(t *testing.T) {
 				testobj.Run("default", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 				testobj.Run("default", "plan-2", "plan", testobj.WithWorkspace("workspace-1")),
 			},
-			assertions: func(queue []string) {
-				require.Equal(t, []string{"plan-1", "plan-2"}, queue)
+			assertions: func(active string, queue []string) {
+				require.Equal(t, "plan-1", active)
+				require.Equal(t, []string{"plan-2"}, queue)
 			},
 		},
 		{
@@ -56,8 +59,9 @@ func TestUpdateQueue(t *testing.T) {
 				testobj.Run("default", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
 				testobj.Run("default", "plan-2", "plan", testobj.WithWorkspace("workspace-1")),
 			},
-			assertions: func(queue []string) {
-				require.Equal(t, []string{"plan-1", "plan-2"}, queue)
+			assertions: func(active string, queue []string) {
+				require.Equal(t, "plan-1", active)
+				require.Equal(t, []string{"plan-2"}, queue)
 			},
 		},
 		{
@@ -66,7 +70,8 @@ func TestUpdateQueue(t *testing.T) {
 			runs: []runtime.Object{
 				testobj.Run("default", "plan-1", "plan", testobj.WithWorkspace("workspace-1"), testobj.WithRunPhase(v1alpha1.RunPhaseCompleted)),
 			},
-			assertions: func(queue []string) {
+			assertions: func(active string, queue []string) {
+				require.Equal(t, "", active)
 				require.Equal(t, []string{}, queue)
 			},
 		},
@@ -77,8 +82,31 @@ func TestUpdateQueue(t *testing.T) {
 				testobj.Run("default", "plan-1", "plan", testobj.WithWorkspace("workspace-1"), testobj.WithRunPhase(v1alpha1.RunPhaseCompleted)),
 				testobj.Run("default", "plan-2", "plan", testobj.WithWorkspace("workspace-1"), testobj.WithRunPhase(v1alpha1.RunPhaseRunning)),
 			},
-			assertions: func(queue []string) {
-				require.Equal(t, []string{"plan-2"}, queue)
+			assertions: func(active string, queue []string) {
+				require.Equal(t, "plan-2", active)
+				require.Equal(t, []string{}, queue)
+			},
+		},
+		{
+			name:      "Unapproved privileged command",
+			workspace: testobj.Workspace("", "workspace-1", testobj.WithPrivilegedCommands("plan")),
+			runs: []runtime.Object{
+				testobj.Run("", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
+			},
+			assertions: func(active string, queue []string) {
+				require.Equal(t, "", active)
+				require.Equal(t, []string{}, queue)
+			},
+		},
+		{
+			name:      "Approved privileged command",
+			workspace: testobj.Workspace("", "workspace-1", testobj.WithPrivilegedCommands("plan"), testobj.WithQueue("plan-1"), testobj.WithApprovals("plan-1")),
+			runs: []runtime.Object{
+				testobj.Run("", "plan-1", "plan", testobj.WithWorkspace("workspace-1")),
+			},
+			assertions: func(active string, queue []string) {
+				require.Equal(t, "plan-1", active)
+				require.Equal(t, []string{}, queue)
 			},
 		},
 	}
@@ -94,7 +122,7 @@ func TestUpdateQueue(t *testing.T) {
 			key := types.NamespacedName{Namespace: tt.workspace.Namespace, Name: tt.workspace.Name}
 			require.NoError(t, c.Get(context.TODO(), key, ws))
 
-			tt.assertions(ws.Status.Queue)
+			tt.assertions(ws.Status.Active, ws.Status.Queue)
 		})
 	}
 }

--- a/pkg/handlers/workspace_queue.go
+++ b/pkg/handlers/workspace_queue.go
@@ -22,20 +22,20 @@ func LogQueuePosition(runName string) watchtools.ConditionFunc {
 	})
 }
 
-// Return true if run is queued
-func IsQueued(runName string) watchtools.ConditionFunc {
+// Return true if run is active
+func IsActive(runName string) watchtools.ConditionFunc {
 	return workspaceHandlerWrapper(func(ws *v1alpha1.Workspace) (bool, error) {
-		if slice.ContainsString(ws.Status.Queue, runName) {
+		if ws.Status.Active == runName {
 			return true, nil
 		}
 		return false, nil
 	})
 }
 
-// Return true if run is in position 0
-func IsFirstPlace(runName string) watchtools.ConditionFunc {
+// Return true if run is queued
+func IsQueued(runName string) watchtools.ConditionFunc {
 	return workspaceHandlerWrapper(func(ws *v1alpha1.Workspace) (bool, error) {
-		if slice.StringIndex(ws.Status.Queue, runName) == 0 {
+		if slice.ContainsString(ws.Status.Queue, runName) {
 			return true, nil
 		}
 		return false, nil

--- a/pkg/testobj/k8s.go
+++ b/pkg/testobj/k8s.go
@@ -48,6 +48,12 @@ func WithHandshake(timeout string) func(*v1alpha1.Workspace) {
 	}
 }
 
+func WithActive(run string) func(*v1alpha1.Workspace) {
+	return func(ws *v1alpha1.Workspace) {
+		ws.Status.Active = run
+	}
+}
+
 func WithQueue(run ...string) func(*v1alpha1.Workspace) {
 	return func(ws *v1alpha1.Workspace) {
 		ws.Status.Queue = run


### PR DESCRIPTION
First position in queue split off into "active' - the run currently running.